### PR TITLE
Add porting guide and other docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# nrf70-bm
-Bare metal nRF70 driver

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,122 @@
+=========================
+nRF70 BM Driver README
+=========================
+
+This document provides instructions on how to set up and use the nRF70 BM driver with `west` for nRF boards or `git submodule` for customer boards.
+
+
+Setup Instructions
+==================
+
+Using `west` for nRF Boards
+---------------------------
+
+For applications integrating the nRF70 Series BM driver it is recommended to use `west` for building and programming  when using official Nordic development boards.
+
+1. **Install West:**
+
+    Follow the instructions on the official Zephyr Project documentation to install `west`:
+    https://docs.zephyrproject.org/latest/guides/west/install.html
+
+2. **Clone the Repository:**
+
+    Clone the main repository using `west`:
+
+    ```sh
+    west init -m https://github.com/nrfconnect/nrf70-bm
+    cd nrf70-bm
+    west update
+    ```
+
+3. **Build the Project:**
+
+    Use `west` to build the project for your specific board:
+
+    ```sh
+    west build -b your_board_name
+    ```
+
+4. **Flash the Board:**
+
+    Flash the firmware onto your nRF board:
+
+    ```sh
+    west flash
+    ```
+
+Using `git submodule` for third-party boards
+--------------------------------------------
+
+1. **Clone the Repository:**
+
+    Clone the main repository and its submodules:
+
+    ```sh
+    git clone https://github.com/nrfconnect/nrf70-bm --recurse-submodules
+    ```
+
+    If you have already cloned the repository without submodules, you can initialize and update the submodules with:
+
+    ```sh
+    git submodule update --init --recursive
+    ```
+
+2. Build and flashing instructions depend on the third-party board and the build system used.
+
+
+Source directory Structure
+==========================
+
+The source directory structure shall look like this:
+
+.. code-block:: none
+
+    nrf70_bm_lib/         # nRF70 BM driver library
+    sdk_nrfxlib/          # nRF Connect SDK nrfxlib
+      nrf_wifi/           # nRF70 Wi-Fi OS agnostic driver
+    samples/              # Sample applications
+      radio_test_bm/      # Radio test sample application
+      scan_bm/            # Scan sample application
+    nrf70_zephyr_shim/    # Zephyr shim for nRF70, reference for third-party boards
+
+
+Porting guide
+=============
+
+The nRF70 Series BM driver is designed to be portable across different platforms.
+The `nrf70_zephyr_shim` directory contains a reference implementation for Zephyr.
+This reference implementation can be used as a guide to port the library to other platforms.
+
+Please refer to `nrf70_bm_lib/docs` for more information on the BM driver and the porting guide.
+
+Documentation
+=============
+
+The documentation for the nRF70 BM driver is available in the `nrf70_bm_lib/docs` directory.
+To build the documentation, follow the below steps:
+
+1. **Install python requirements:**
+
+    Install the required python packages using `pip`:
+
+    ```sh
+    pip install -r nrf70_bm_lib/docs/requirements.txt
+    ```
+2. ** Install doxygen:**
+
+    Install doxygen using `apt` package manager (or any other package manager based on your OS):
+
+    ```sh
+    sudo apt install doxygen
+    ```
+3. **Build the Documentation:**
+
+    Build the documentation using the following command:
+
+    ```sh
+    ./build_docs.sh
+    ```
+
+    The generated HTML files will be available in `nrf70_bm_lib/docs/build/html`.
+
+    Open the `index.html` file in a browser to view the documentation.

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Function to generate Doxygen XML files
+generate_doxygen_xml() {
+    echo "Generating Doxygen XML files..."
+    doxygen Doxyfile
+}
+
+# Function to build Sphinx documentation
+build_sphinx_docs() {
+    echo "Building Sphinx documentation..."
+    make html
+}
+
+# Main script execution
+main() {
+    cd nrf70_bm_lib/docs
+    generate_doxygen_xml
+    build_sphinx_docs
+
+    echo "Documentation build complete. The HTML files are located in nrf70_bm_lib/docs/build/html."
+}
+
+# Run the main function
+main

--- a/nrf70_bm_lib/docs/requirements.txt
+++ b/nrf70_bm_lib/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+breathe
+sphinx_rtd_theme

--- a/nrf70_bm_lib/docs/source/conf.py
+++ b/nrf70_bm_lib/docs/source/conf.py
@@ -33,5 +33,4 @@ exclude_patterns = []
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = 'sphinx_rtd_theme'

--- a/nrf70_bm_lib/docs/source/index.rst
+++ b/nrf70_bm_lib/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to nRF70 bare metal library's documentation!
    :caption: Contents:
 
    nrf70_bm_lib
+   nrf70_bm_porting_guide
    nrf70_bm_api
 
 

--- a/nrf70_bm_lib/docs/source/nrf70_bm_porting_guide.rst
+++ b/nrf70_bm_lib/docs/source/nrf70_bm_porting_guide.rst
@@ -1,0 +1,68 @@
+.. _nrf70_bm_porting_guide:
+
+nRF70 Series BM driver Porting Guide
+====================================
+The nRF70 Series BM driver is designed to be portable across different platforms.
+This guide provides an overview of the nRF70 Series BM library and the steps to port the library to a new platform.
+
+nRF70 Series driver threading model
+***********************************
+
+The nRF70 Series BM driver uses a simple threading model to interact with the nRF70 Series device.
+The driver code executes in the following contexts:"
+
+* *Interrupt context*: For handling interrupts from the nRF70 Series. Interrupt service routines are used to schedule tasklets to offload the nRF70 Series event handling.
+  The nRF70 device requires a single  `host IRQ` interrupt line to raise interrupts on the host platform, when the device needs to report an event. A GPIO pin needs to be configured as a `host IRQ` at the host MCU.
+  The interrupt service routine reads the event coming from the nRF70 Series device and schedules a tasklet to handle the event.
+* *Tasklet context*: Tasklets perform the actual work of interacting with the nRF70 Series device
+  - processing events coming from the nRF70 device
+  - writing and submitting commands to the nRF70 device
+  RX tasklet: The RX tasklet reads the event data from the nRF70 Series and hands over to the FMAC callbacks.
+* *Application thread context*: The application thread context is responsible for calling the nRF70 Series BM driver APIs to interact with the nRF70 Series device.
+
+Zephyr shim reference
+**********************
+
+
+The `the nRF70 Series_zephyr_shim` directory contains a reference implementation for Zephyr.
+This reference implementation can be used as a guide to port the library to other platforms.
+This reference implementation is structured in multiple source directories as follows :
+
+.. code-block:: none
+
+    the nRF70 Series_zephyr_shim/     # Zephyr shim for the nRF70 Series, reference for third-party host platforms
+      include/             # Include directory
+      source/              # Source directory
+        bus/               # Bus interface
+        os/                # OS shim
+        platform/          # Platform specific files
+      CMakeLists.txt       # CMake build file```
+
+The key components of the Zephyr shim reference implementation are:
+
+* *os*: Contains the OS shim implementation for Zephyr.
+* *bus*: Contains the bus interface implementation for SPI.
+* *platform*: Contains the platform specific files, and has an RPU (Radio Processing Unit) abstraction layer that interacts with the nRF70 Series
+  either through QSPI or SPI. The platform also uses Zephyr GPIO APIs to manage GPIO pins of the nRF70 Series.
+
+Zephyr functionality used in the reference implementation:
+**********************************************************
+
+The reference implementation of the BM Driver for the Zephyr RTOS uses build-time tools as well as standard OS primitives; these elements require porting effort when integrating the driver to a third-party (non-Zephyr) platform.
+
+* OS primitives: The reference implementation uses the following Zephyr OS primitives:
+
+    - Workqueue: Used to schedule work or delayed work to be done.
+    - Heap: Used to allocate memory for the nRF70 Series.
+    - Lists: Used to manage the list of tasks to be done in the context of the nRF70 Series.
+    - Sleep/Delay: Used to manage the sleep and delay for the nRF70 Series.
+    - Semaphore: Used to manage the synchronization between the nRF70 Series and the host MCU.
+* Driver model: The reference implementation uses the Zephyr driver model to manage the nRF70 Series device.
+
+    - SPI: Uses Zephyr's SPI driver to communicate with the nRF70 Series over SPI.
+    - GPIO: Used to manage the host IRQ GPIO pin of the nRF70 Series.
+
+* Build time tools: The reference implementation uses the following build-time tools:
+
+    - DTS: Used to define the GPIO pins of the nRF70 Series.
+    - Kconfig: Used to define the configuration options for the nRF70 Series driver.


### PR DESCRIPTION
Add a README at the root and then porting guide and also switch the theme from Alabaster to RTD, this is inline with ZephyrRTOS theme.