### PR TITLE
samples: scan_bm: Fix max-channels for 5GHz

### DIFF
--- a/samples/scan_bm/Kconfig
+++ b/samples/scan_bm/Kconfig
@@ -131,4 +131,9 @@ config WIFI_SCAN_REG_DOMAIN
 	help
 	  Specifies the regulatory domain to be used for the scan.
 
+if WIFI_SCAN_PROFILE_5GHz_NON_DFS_CHAN || WIFI_SCAN_PROFILE_2_4GHz_NON_OVERLAP_AND_5GHz_NON_DFS_CHAN
+config WIFI_MGMT_SCAN_CHAN_MAX_MANUAL
+	default 12
+endif
+
 endmenu


### PR DESCRIPTION
When 5GHz is used (standalone or with 2.4GHz) the maximum channels allowed should be increase to avoid scan failure.

Fixes SHEL-3196.