### PR TITLE
Add supprot to publish docs to nRF github.io

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -91,3 +91,30 @@ jobs:
             nrf70_bm_ws/nrf70-bm/nrf70_bm_lib/*.zip
             nrf70_bm_ws/nrf70-bm/nrf70_bm_lib/monitor*.txt
             nrf70_bm_ws/nrf70-bm/nrf70_bm_lib/pr.txt
+
+      - name: Setup pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v4
+
+      - name: Upload pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: nrf70_bm_ws/nrf70-bm/nrf70_bm_lib/doc/build/html
+
+      - name: Upload artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          path: nrf70_bm_ws/nrf70-bm/nrf70_bm_lib/doc/build/html
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This helps get a shareable link, easier to review rendered docs.