### PR TITLE
Replace STRINGIFY with STR and pull fix for op_mode check

### DIFF
--- a/nrf70_bm_lib/source/radio_test/nrf70_bm_core.c
+++ b/nrf70_bm_lib/source/radio_test/nrf70_bm_core.c
@@ -89,7 +89,7 @@ int nrf70_bm_rt_fmac_init(void)
 					   &tx_pwr_ctrl_params,
 					   &tx_pwr_ceil_params,
 					   &board_params,
-					   STRINGIFY(CONFIG_NRF70_REG_DOMAIN));
+					   STR(CONFIG_NRF70_REG_DOMAIN));
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		NRF70_LOG_ERR("Failed to initialize device\n");
 		goto deinit;

--- a/nrf70_bm_lib/source/system/nrf70_bm_core.c
+++ b/nrf70_bm_lib/source/system/nrf70_bm_core.c
@@ -390,7 +390,7 @@ int nrf70_bm_sys_fmac_init(void)
 					    &tx_pwr_ctrl_params,
 					    &tx_pwr_ceil_params,
 					    &board_params,
-					    STRINGIFY(CONFIG_NRF70_REG_DOMAIN));
+					    STR(CONFIG_NRF70_REG_DOMAIN));
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		NRF70_LOG_ERR("Failed to initialize device\n");
 		goto deinit;

--- a/west.yml
+++ b/west.yml
@@ -29,7 +29,7 @@ manifest:
     # nRF70 Wi-Fi OSAL library
     - name: nrf_wifi
       repo-path: nrf_wifi
-      revision: 36262fa1a3305b297a6c9fefedd84106ad162e0e
+      revision: a4e0a470fffdead2af5bcd63eac050b6614a7281
       path: modules/lib/nrf_wifi
     # nRF70 Wi-Fi firmware blobs (without west blobs fetch)
     - name: nrfxlib


### PR DESCRIPTION
1. Replace usage of zephyr specific STRINGIFY with OS agnostic STR.
2. Pull in fix for validating op_mode in respective APIs.