### PR TITLE
Fix for crash and documentation update

### DIFF
--- a/nrf70_bm_lib/docs/source/nrf70_bm_porting_guide.rst
+++ b/nrf70_bm_lib/docs/source/nrf70_bm_porting_guide.rst
@@ -7,8 +7,8 @@ The nRF70 Series BM driver is designed to be portable across different platforms
 This guide provides an overview of the steps required to port the library to a new platform or OS environment.
 
 
-Zephyr functionality used in the reference implementation:
-**********************************************************
+Zephyr functionality used in the reference implementation
+*********************************************************
 
 The reference implementation of the BM Driver for the Zephyr RTOS uses build-time tools as well as standard OS primitives; these elements require porting effort when integrating the driver to a third-party (non-Zephyr) platform.
 
@@ -94,13 +94,14 @@ OS agnostic driver layer
 ************************
 
 The BM library uses the OS-agnostic nRF70 Wi-Fi driver layer to interact with the nRF70 Series device.
-This layer is pulled in as a submodule from the nRF Connect SDK nrfxlib repository using a custom branch.
+This layer is pulled in as the following submodules:
 
-For more information, visit the `nRF Connect SDK nrfxlib repository <https://github.com/nrfconnect/sdk-nrfxlib>`_.
+* *Driver* : From the Zephyr Project nrf_wifi repository. For more information, visit the `Zephyr project nrf_wifi repository <https://github.com/zephyrproject-rtos/nrf_wifi>`_.
+* *Firmware patches*: From the nRF Connect SDK nrfxlib repository. For more information, visit the `nRF Connect SDK nrfxlib repository <https://github.com/nrfconnect/sdk-nrfxlib>`_.
 
 .. note ::
 
-   The git submodule pulls in the entire repo, but only `nrf_wifi` directory is required for the BM driver.
+   The BM driver used the firmware patches from <https://github.com/nrfconnect/sdk-nrfxlib/tree/main/nrf_wifi/bin/zephyr>.
 
 Transmit (TX) power configuration
 *********************************

--- a/nrf70_bm_lib/source/radio_test/nrf70_bm_core.c
+++ b/nrf70_bm_lib/source/radio_test/nrf70_bm_core.c
@@ -99,7 +99,6 @@ int nrf70_bm_rt_fmac_init(void)
 
 	return 0;
 deinit:
-	nrf_wifi_osal_deinit();
 	nrf70_bm_rt_fmac_deinit();
 err:
 	return -1;

--- a/nrf70_bm_lib/source/system/nrf70_bm_core.c
+++ b/nrf70_bm_lib/source/system/nrf70_bm_core.c
@@ -400,7 +400,6 @@ int nrf70_bm_sys_fmac_init(void)
 
 	return 0;
 deinit:
-	nrf_wifi_osal_deinit();
 	nrf70_bm_sys_fmac_deinit();
 err:
 	return -1;


### PR DESCRIPTION
Updates for:

1. Fixing a driver crash in the deinit path
2. Documentation updates.