### PR TITLE
Fix crash in nrf70_bm_rt_init

### DIFF
--- a/nrf70_bm_lib/source/radio_test/nrf70_bm_lib.c
+++ b/nrf70_bm_lib/source/radio_test/nrf70_bm_lib.c
@@ -30,7 +30,7 @@ int nrf70_bm_rt_init(struct nrf70_bm_regulatory_info *reg_info)
 		goto deinit;
 	}
 
-	ret = nrf70_bm_rt_fmac_get_reg(&reg_info_curr);
+	ret = nrf70_bm_rt_get_reg(&reg_info_curr);
 	if (ret) {
 		NRF70_LOG_ERR("Failed to get regulatory info");
 		goto deinit;
@@ -48,17 +48,17 @@ int nrf70_bm_rt_init(struct nrf70_bm_regulatory_info *reg_info)
 			goto deinit;
 		}
 
-		memset(reg_info->chan_info,
+		memset(reg_info_curr.chan_info,
 		       0,
 		       sizeof(struct nrf70_bm_reg_chan_info) * NRF70_MAX_CHANNELS);
 
-		ret = nrf70_bm_rt_get_reg(reg_info);
+		ret = nrf70_bm_rt_get_reg(&reg_info_curr);
 		if (ret) {
 			printf("Failed to get regulatory info: %d\n", ret);
 			return -1;
 		}
 
-		printf("Regulatory country code set to: %s\n", reg_info->country_code);
+		printf("Regulatory country code set to: %s\n", reg_info_curr.country_code);
 	}
 	return 0;
 deinit:

--- a/nrf70_bm_lib/source/system/nrf70_bm_lib.c
+++ b/nrf70_bm_lib/source/system/nrf70_bm_lib.c
@@ -116,7 +116,7 @@ int nrf70_bm_sys_init(uint8_t *mac_addr,
 	       sizeof(struct nrf70_bm_reg_chan_info) *
 	       NRF70_MAX_CHANNELS);
 
-	ret = nrf70_bm_sys_fmac_get_reg(&reg_info_curr);
+	ret = nrf70_bm_sys_get_reg(&reg_info_curr);
 	if (ret) {
 		NRF70_LOG_ERR("Failed to get regulatory info");
 		goto deinit;

--- a/samples/radio_test_bm/src/nrf_wifi_radio_test_main.c
+++ b/samples/radio_test_bm/src/nrf_wifi_radio_test_main.c
@@ -34,13 +34,6 @@ int main(void)
 	memcpy(reg_info.country_code, CONFIG_WIFI_RT_REG_DOMAIN, 2);
 	reg_info.force = true;
 
-	reg_info.chan_info = malloc(sizeof(struct nrf70_bm_reg_chan_info) * NRF70_MAX_CHANNELS);
-	if (!reg_info.chan_info) {
-		printf("Failed to allocate memory for regulatory info\n");
-		ret = -ENOMEM;
-		goto cleanup;
-	}
-
 	/* Initialize the Wi-Fi module */
 	CHECK_RET(nrf70_bm_rt_init(&reg_info));
 	printf("Initialized WiFi module, ready for radio test\n");
@@ -52,10 +45,6 @@ int main(void)
 	}
 
 cleanup:
-	if (reg_info.chan_info) {
-		free(reg_info.chan_info);
-	}
-
 	if (ret) {
 		nrf70_bm_rt_deinit();
 		printf("Exiting WiFi radio test sample application with error: %d\n", ret);

--- a/samples/scan_rt_bm/src/main.c
+++ b/samples/scan_rt_bm/src/main.c
@@ -226,13 +226,6 @@ int main(void)
 	int ret = -1;
 	int i;
 
-	reg_info.chan_info = malloc(sizeof(struct nrf70_bm_reg_chan_info) * NRF70_MAX_CHANNELS);
-	if (!reg_info.chan_info) {
-		printf("Failed to allocate memory for regulatory info\n");
-		ret = -ENOMEM;
-		goto cleanup;
-	}
-
 	for (i = 0; i < 2; i++) {
 		/*
 		 * Radio test operation
@@ -318,11 +311,6 @@ int main(void)
 
 	ret = 0;
 cleanup:
-	if (reg_info.chan_info) {
-			free(reg_info.chan_info);
-			reg_info.chan_info = NULL;
-	}
-
 	if (sys_init) {
 		nrf70_bm_sys_deinit();
 		sys_init = false;


### PR DESCRIPTION
Fix a crash if the chan_info element of reg_info parameter being passed to nrf70_bm_rt_init is not initialized to a non NULL value. This is not necessary and can be managed withing the library API.