### PR TITLE
Ignore failures in deinit

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -15,10 +15,11 @@ on:
 
 env:
   DOXYGEN_VERSION: 1.12.0
+  DOXYGEN_MD5SUM: fd96a5defa535dfe2e987b46540844a4
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
@@ -37,19 +38,29 @@ jobs:
       - name: Install packages
         working-directory: nrf70_bm_ws
         run: |
-          sudo apt update
-          sudo apt-get install -y ninja-build mscgen plantuml
-          sudo snap install yq
+          sudo apt-get update
+          sudo apt-get install -y wget python3-pip git ninja-build graphviz lcov
           wget --no-verbose "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
-          tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
-          echo "${PWD}/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
+          echo "${DOXYGEN_MD5SUM}  doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" | md5sum -c
+          if [ $? -ne 0 ]; then
+            echo "Failed to verify doxygen tarball"
+            exit 1
+          fi
+          sudo tar xf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz -C /opt
+          echo "/opt/doxygen-${DOXYGEN_VERSION}/bin" >> $GITHUB_PATH
+          echo "${HOME}/.local/bin" >> $GITHUB_PATH
 
-      - name: Install Python dependencies
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: 3.12
+          cache: pip
+          cache-dependency-path: zephyr/doc/requirements.txt
+
+      - name: install-pip
         working-directory: nrf70_bm_ws
         run: |
-          sudo pip3 install -U setuptools wheel pip
-          pip3 install -r zephyr/doc/requirements.txt
-          # docs still use breathe (based on NCS)
+          pip install -r zephyr/doc/requirements.txt --require-hashes
           pip install breathe
 
       - name: West zephyr-export

--- a/nrf70_bm_lib/source/system/nrf70_bm_lib.c
+++ b/nrf70_bm_lib/source/system/nrf70_bm_lib.c
@@ -187,18 +187,14 @@ int nrf70_bm_sys_deinit(void)
 	ret = nrf70_bm_sys_fmac_del_vif_sta();
 	if (ret) {
 		NRF70_LOG_ERR("Failed to delete STA VIF");
-		goto err;
 	}
 
 	// Clean up the WiFi module
 	ret = nrf70_bm_sys_fmac_deinit();
 	if (ret) {
 		NRF70_LOG_ERR("Failed to deinitialize FMAC module");
-		goto err;
 	}
 
-	return 0;
-err:
 	return ret;
 }
 


### PR DESCRIPTION
During de-initialization we might encounter a scenario where nRF70 is stuck or unresponsive, so, no point in aborting the deinit sequence, instead go ahead and power down the nRF70 and may be subsequent init will get it operational.

Note: We use the same strategy in the non-BM case too.