### PR TITLE
manifest: Fix the Zephyr version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
     # For testing with nRF boards
     - name: zephyr
       repo-path: zephyr
-      revision: main
+      revision: v4.1.0
       import:
         name-allowlist:
           - hal_nordic


### PR DESCRIPTION
Using main can break stuff randomly, use only the release version.

Signed-off-by: Chaitanya Tata <Chaitanya.Tata@nordicsemi.no>